### PR TITLE
Add aria-label to HistorySuggestions. Prevent VoiceOver double click

### DIFF
--- a/frontend/portals/HistorySuggestions/components/SuggestionList/components/List/components/Item/index.jsx
+++ b/frontend/portals/HistorySuggestions/components/SuggestionList/components/List/components/Item/index.jsx
@@ -109,11 +109,11 @@ class Item extends Component {
     }
 
     return (
-      <div aria-hidden onClick={this.props.onClick} data-test-id={this.props.testId}>
+      <button type="button" onClick={this.props.onClick} data-test-id={this.props.testId} aria-label={this.props.title}>
         <Glow className={this.props.className}>
           {this.renderContent()}
         </Glow>
-      </div>
+      </button>
     );
   }
 }

--- a/frontend/portals/HistorySuggestions/index.jsx
+++ b/frontend/portals/HistorySuggestions/index.jsx
@@ -46,8 +46,10 @@ const HistorySuggestions = ({
    * @param {string} searchTerm searchTerm
    */
   const handleClick = (e, searchTerm) => {
-    e.currentTarget.value = searchTerm;
-    onClick(e, searchTerm);
+    setTimeout(() => {
+      e.currentTarget.value = searchTerm;
+      onClick(e, searchTerm);
+    }, 0);
   };
 
   return (

--- a/frontend/portals/HistorySuggestions/index.jsx
+++ b/frontend/portals/HistorySuggestions/index.jsx
@@ -46,6 +46,7 @@ const HistorySuggestions = ({
    * @param {string} searchTerm searchTerm
    */
   const handleClick = (e, searchTerm) => {
+    // setTimeout prevents double click while VoiceOver is active
     setTimeout(() => {
       e.currentTarget.value = searchTerm;
       onClick(e, searchTerm);


### PR DESCRIPTION
# Pull Request Template

## Description

Add aria-label to HistorySuggestions. Prevent VoiceOver double click

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I updated the CHANGELOG.md